### PR TITLE
Update pom.xml to exclude storm hive tests

### DIFF
--- a/external/storm-hive/pom.xml
+++ b/external/storm-hive/pom.xml
@@ -182,6 +182,17 @@
           </execution>
         </executions>
       </plugin>
+      <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-surefire-plugin</artifactId>
+            <version>2.17</version>
+            <configuration>
+              <excludes>
+                  <exclude>**/TestHiveBolt.java</exclude>
+                  <exclude>**/TestHiveWriter.java</exclude>
+              </excludes>
+            </configuration>
+      </plugin>
     </plugins>
   </build>
 


### PR DESCRIPTION
“checkEndPoint()” in HDP-hive/hcatalog/streaming/src/java/org/apache/hive/hcatalog/streaming/HiveEndPoint.java is validating whether the "transactional" property is set to true on the table which is not set in this case. So excluding the tests in the pom.xml

Resolves #1 
